### PR TITLE
Fix: changed caching and fetching process for charts (less loading time)

### DIFF
--- a/src/components/analytics/technicals/TechnicalsTab.tsx
+++ b/src/components/analytics/technicals/TechnicalsTab.tsx
@@ -1,20 +1,28 @@
-import MACDChart from "./charts/MACDChart";
-import PriceTrendChart from "./charts/PriceTrendChart";
-import VolumeChart from "./charts/VolumeChart";
-import RSIChart from "./charts/RSIChart";
-import BollingerBandsChart from "./charts/BollingerBandsChart";
-import StochasticOscillatorChart from "./charts/StochasticOscillatorChart";
-import WilliamsChart from "./charts/WilliamsChart";
-import ADXChart from "./charts/ADXChart";
-import CMFChart from "./charts/CMFChart";
+import ChartComponent from "./charts/ChartComponent";
 import TechnicalAnalysis from "./TechnicalAnalysis";
 import { useTranslation } from "react-i18next";
 
+const chartConfigs = [
+  { title: "Price Trend", name: "price_trend" },
+  { title: "Volume", name: "on_balance_volume_chart" },
+  { title: "MACD", name: "macd" },
+  { title: "RSI", name: "rsi" },
+  { title: "Bollinger Bands", name: "bollinger_bands_plot" },
+  { title: "Stochastic Oscillator", name: "stochastic_oscillator_plot" },
+  { title: "Williams", name: "williams_r_plot" },
+  { title: "ADX", name: "adx_plot" },
+  { title: "CMF", name: "cmf", span: 2 },
+];
+
+import { useTicker } from "../../../hooks/useTicker"; 
+
 const TechnicalsTab: React.FC = () => {
   const { t } = useTranslation();
+  const { ticker } = useTicker();
+
   return (
     <div className="min-h-full h-full w-full relative">
-      <div className="grid lg:grid-cols-1 ">
+      <div className="grid lg:grid-cols-1">
         <div className="bg-white p-4 shadow-sm space-y-4 xl:col-span-2">
           <h2 className="text-3xl leading-8 font-extrabold tracking-tight text-gray-900 sm:text-4xl p-6">
             {t("analytics_page.technicals.technical_analysis")}
@@ -33,68 +41,19 @@ const TechnicalsTab: React.FC = () => {
           </h2>
         </div>
 
-        <div className="bg-white p-6 shadow-sm space-y-4 place-items-center ">
-          <h2 className="text-base text-blue-600 font-semibold tracking-wide uppercase">
-            Price Trend
-          </h2>
-          <PriceTrendChart />
-        </div>
-
-        <div className="bg-white p-6 shadow-sm space-y-4 place-items-center ">
-          <h2 className="text-base text-blue-600 font-semibold tracking-wide uppercase">
-            Volume
-          </h2>
-          <VolumeChart />
-        </div>
-
-        <div className="bg-white p-6 shadow-sm space-y-4 place-items-center ">
-          <h2 className="text-base text-blue-600 font-semibold tracking-wide uppercase">
-            MACD
-          </h2>
-          <MACDChart />
-        </div>
-
-        <div className="bg-white p-6 shadow-sm space-y-4 place-items-center ">
-          <h2 className="text-base text-blue-600 font-semibold tracking-wide uppercase">
-            RSI
-          </h2>
-          <RSIChart />
-        </div>
-
-        <div className="bg-white p-6 shadow-sm space-y-4 place-items-center ">
-          <h2 className="text-base text-blue-600 font-semibold tracking-wide uppercase">
-            Bollinger Bands
-          </h2>
-          <BollingerBandsChart />
-        </div>
-
-        <div className="bg-white p-6 shadow-sm space-y-4 place-items-center ">
-          <h2 className="text-base text-blue-600 font-semibold tracking-wide uppercase">
-            Stochastic Oscillator
-          </h2>
-          <StochasticOscillatorChart />
-        </div>
-
-        <div className="bg-white p-6 shadow-sm space-y-4 place-items-center ">
-          <h2 className="text-base text-blue-600 font-semibold tracking-wide uppercase">
-            Williams
-          </h2>
-          <WilliamsChart />
-        </div>
-
-        <div className="bg-white p-6 shadow-sm space-y-4 place-items-center ">
-          <h2 className="text-base text-blue-600 font-semibold tracking-wide uppercase">
-            ADX
-          </h2>
-          <ADXChart />
-        </div>
-
-        <div className="bg-white p-6 shadow-sm space-y-4 xl:col-span-2 place-items-center mb-4">
-          <h2 className="text-base text-blue-600 font-semibold tracking-wide uppercase">
-            CMF
-          </h2>
-          <CMFChart />
-        </div>
+        {chartConfigs.map(({ title, name, span }) => (
+          <div
+            key={name}
+            className={`bg-white p-6 shadow-sm space-y-4 place-items-center ${
+              span === 2 ? "xl:col-span-2" : ""
+            }`}
+          >
+            <h2 className="text-base text-blue-600 font-semibold tracking-wide uppercase">
+              {title}
+            </h2>
+            <ChartComponent chartName={name} ticker={ticker} />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/analytics/technicals/charts/ChartComponent.tsx
+++ b/src/components/analytics/technicals/charts/ChartComponent.tsx
@@ -3,10 +3,9 @@ import { fetchSingleChart } from "../../../../utilities/api";
 import { ChartComponentProps } from "../../../../types/interfaces";
 import TradexLogo from "../../../../assets/tradex-logo.svg";
 
-const ChartComponent: React.FC<ChartComponentProps> = ({
-  ticker,
-  chartName,
-}) => {
+const chartCache: Record<string, string> = {};
+
+const ChartComponent: React.FC<ChartComponentProps> = ({ ticker, chartName }) => {
   const [chartHtml, setChartHtml] = useState<string>("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -21,8 +20,16 @@ const ChartComponent: React.FC<ChartComponentProps> = ({
     setLoading(true);
     setError(null);
 
+    const cacheKey = `${ticker}_${chartName}`;
+    if (chartCache[cacheKey]) {
+      setChartHtml(chartCache[cacheKey]);
+      setLoading(false);
+      return;
+    }
+
     try {
       const response = await fetchSingleChart(chartName, ticker);
+      chartCache[cacheKey] = response;
       setChartHtml(response);
     } catch {
       handleError("Failed to load chart.");
@@ -59,7 +66,7 @@ const ChartComponent: React.FC<ChartComponentProps> = ({
           <img
             src={TradexLogo}
             alt="Loading"
-            className="w-40 h-40 animate-pulse "
+            className="w-40 h-40 animate-pulse"
           />
         </div>
       ) : error ? (
@@ -67,7 +74,7 @@ const ChartComponent: React.FC<ChartComponentProps> = ({
           <img
             src={TradexLogo}
             alt="Loading"
-            className="w-40 h-40 animate-pulse "
+            className="w-40 h-40 animate-pulse"
           />
           <p className="text-gray-900 bg-black">{error}</p>
         </div>

--- a/src/context/ChartCacheContext.tsx
+++ b/src/context/ChartCacheContext.tsx
@@ -1,9 +1,10 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import { fetchSingleChart } from "../utilities/api";
 
 interface ChartCacheContextType {
   charts: Record<string, string>;
   loadCharts: (ticker: string, chartNames: string[]) => Promise<void>;
+  clearCharts: () => void;
 }
 
 const ChartCacheContext = createContext<ChartCacheContextType | null>(null);
@@ -25,8 +26,21 @@ export const ChartCacheProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     setCharts(prev => ({ ...prev, ...newCharts }));
   };
 
+  const clearCharts = () => {
+    setCharts({});
+  };
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      clearCharts();
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, []);
+
   return (
-    <ChartCacheContext.Provider value={{ charts, loadCharts }}>
+    <ChartCacheContext.Provider value={{ charts, loadCharts, clearCharts }}>
       {children}
     </ChartCacheContext.Provider>
   );

--- a/src/context/ChartCacheContext.tsx
+++ b/src/context/ChartCacheContext.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState } from "react";
+import { fetchSingleChart } from "../utilities/api";
+
+interface ChartCacheContextType {
+  charts: Record<string, string>;
+  loadCharts: (ticker: string, chartNames: string[]) => Promise<void>;
+}
+
+const ChartCacheContext = createContext<ChartCacheContextType | null>(null);
+
+export const ChartCacheProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [charts, setCharts] = useState<Record<string, string>>({});
+
+  const loadCharts = async (ticker: string, chartNames: string[]) => {
+    const newCharts: Record<string, string> = {};
+    await Promise.all(
+      chartNames.map(async (chartName) => {
+        const key = `${ticker}_${chartName}`;
+        if (!charts[key]) {
+          const html = await fetchSingleChart(chartName, ticker);
+          newCharts[key] = html;
+        }
+      })
+    );
+    setCharts(prev => ({ ...prev, ...newCharts }));
+  };
+
+  return (
+    <ChartCacheContext.Provider value={{ charts, loadCharts }}>
+      {children}
+    </ChartCacheContext.Provider>
+  );
+};
+
+export const useChartCache = () => {
+  const context = useContext(ChartCacheContext);
+  if (!context) throw new Error("useChartCache must be used within ChartCacheProvider");
+  return context;
+};

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -3,6 +3,7 @@ import App from "./App";
 import LandingPage from "./components/pages/LandingPage";
 import AnalyticsPage from "./components/pages/AnalyticsPage";
 import { TickerProvider } from "./context/TickerProvider";
+import { ChartCacheProvider } from "./context/ChartCacheContext";
 
 export const router = createBrowserRouter([
   {
@@ -13,8 +14,15 @@ export const router = createBrowserRouter([
       </TickerProvider>
     ),
     children: [
-      { index: true, element: <LandingPage /> }, // Default route
-      { path: "analytics", element: <AnalyticsPage /> },
+      { index: true, element: <LandingPage /> },
+      {
+        path: "analytics",
+        element: (
+          <ChartCacheProvider>
+            <AnalyticsPage />
+          </ChartCacheProvider>
+        ),
+      },
     ],
   },
 ]);


### PR DESCRIPTION
The fix should save the loaded charts to the cache, so that they don't have to be re-fetched again when you go back to the analytics page where the charts are visible.

The charts will be deleted from the cache the moment you close the tab, or navigate away from it in some other way.
